### PR TITLE
Ensure outbound links open in new tab

### DIFF
--- a/scripts/templates/home.html.j2
+++ b/scripts/templates/home.html.j2
@@ -211,7 +211,7 @@
 
 <div class="container">
     <div class="welcome">
-        <a href="https://fosdem.org/{{ fosdem_year }}/" target="_blank">
+        <a href="https://fosdem.org/{{ fosdem_year }}/" target="_blank" rel="noopener noreferrer">
             <svg width="54" height="54" viewBox="0 0 54 54" fill="none"
                  xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -234,12 +234,12 @@
         <p>Welcome to our fully virtual version of the ULB, thanks to the amazing people at Matrix.org! FOSDEM is
             spread out over a lot of rooms at <i>chat.fosdem.org</i>.</p>
         <p>The main conference floor is at <a href="/#/room/#fosdem2022:fosdem.org">#fosdem2022:fosdem.org</a>.</p>
-        <p><a href="https://www.fosdem.org/{{ fosdem_year }}/schedule/">You can visit the schedule</a> to find out
+        <p><a href="https://www.fosdem.org/{{ fosdem_year }}/schedule/" target="_blank" rel="noopener noreferrer">You can visit the schedule</a> to find out
             what's on in each room,
             click on your favourite room and then sit back and relax.</p>
-        <p>Confused? Unsure how to proceed? <a href="https://www.fosdem.org/{{ fosdem_year }}/practical/online/">Visit
+        <p>Confused? Unsure how to proceed? <a href="https://www.fosdem.org/{{ fosdem_year }}/practical/online/" target="_blank" rel="noopener noreferrer">Visit
             the practical information page</a>,
-            <a href="https://www.fosdem.org/{{ fosdem_year }}/faq/">look in the FAQ</a>
+            <a href="https://www.fosdem.org/{{ fosdem_year }}/faq/" target="_blank" rel="noopener noreferrer">look in the FAQ</a>
             or <a href="/#/room/#INFODESK:fosdem.org">talk to a
                 human at the Infodesk</a>!</p>
     </div>
@@ -314,7 +314,7 @@
                         <p>{{ main_track.title }}</p>
                     </div>
                     <div class="room_subtext">
-                        <p><a href="https://www.fosdem.org/{{ fosdem_year }}/schedule/track/{{ main_track.slug }}/">Schedule</a>
+                        <p><a href="https://www.fosdem.org/{{ fosdem_year }}/schedule/track/{{ main_track.slug }}/" target="_blank" rel="noopener noreferrer">Schedule</a>
                         </p>
                     </div>
                     <div class="btn"><a href="/#/room/#{{ main_track.room_name }}:fosdem.org">
@@ -339,7 +339,7 @@
                         <p>{{ devroom.title }}</p>
                     </div>
                     <div class="room_subtext">
-                        <p><a href="https://www.fosdem.org/{{ fosdem_year }}/schedule/track/{{ devroom.slug }}/">Schedule</a>
+                        <p><a href="https://www.fosdem.org/{{ fosdem_year }}/schedule/track/{{ devroom.slug }}/" target="_blank" rel="noopener noreferrer">Schedule</a>
                         </p>
                     </div>
                     <div class="btn"><a href="/#/room/#{{ devroom.room_name }}:fosdem.org">
@@ -365,7 +365,7 @@
                     </div>
                     <div class="room_subtext">
                         <p>
-                            <a href="https://www.fosdem.org/{{ fosdem_year }}/schedule/track/{{ stand.slug }}/">Schedule</a>
+                            <a href="https://www.fosdem.org/{{ fosdem_year }}/schedule/track/{{ stand.slug }}/" target="_blank" rel="noopener noreferrer">Schedule</a>
                         </p>
                     </div>
                     <div class="btn"><a href="/#/room/#{{ stand.room_name }}:fosdem.org">


### PR DESCRIPTION
Otherwise visiting the schedule and clicking back will break Element from loading *if* the user has clicked one of the hash urls to get to a section on the page. Also loading Element takes time, so a new tab is friendlier as well.

Additionally add `rel="noopener noreferrer"` to the new links as good practice.