### PR TITLE
Fix link to conference floor

### DIFF
--- a/scripts/templates/home.html.j2
+++ b/scripts/templates/home.html.j2
@@ -233,7 +233,7 @@
         <h1>Welcome to FOSDEM {{ fosdem_year }}!</h1>
         <p>Welcome to our fully virtual version of the ULB, thanks to the amazing people at Matrix.org! FOSDEM is
             spread out over a lot of rooms at <i>chat.fosdem.org</i>.</p>
-        <p>The main conference floor is at <a href="/#/room/#fosdem2022:fosdem.org">#fosdem2022:fosdem.org</a>.</p>
+        <p>The main <a href="/#/room/#fosdem2022:fosdem.org">conference floor</a> is where all the action is.</p>
         <p><a href="https://www.fosdem.org/{{ fosdem_year }}/schedule/" target="_blank" rel="noopener noreferrer">You can visit the schedule</a> to find out
             what's on in each room,
             click on your favourite room and then sit back and relax.</p>


### PR DESCRIPTION
If it's a space alias, Element turns it into a matrix.to link, which doesn't properly work as it should in-app in the home page. Make it a link with non-alias text instead.