### PR TITLE
Draft: oniro: Rename stand to be listed

### DIFF
--- a/scripts/pentabarf.yaml
+++ b/scripts/pentabarf.yaml
@@ -8839,27 +8839,27 @@ tracks:
     end_time_index:
       saturday: 120
       sunday: 
-  openharmony_project_stand:
+  oniro_project_stand:
     conference_track_id: 1064
-    conference_track: OpenHarmony Project stand
+    conference_track: Oniro Project stand
     rank: 2250
     conference_call_for_papers_url: 
-    name: OpenHarmony Project stand
-    title: OpenHarmony Project stand
+    name: Oniro Project stand
+    title: Oniro Project stand
     type: standtrack
-    slug: openharmony_project_stand
+    slug: onrio_project_stand
     events:
-    - openharmony_welcome
+    - oniro_welcome
     events_by_day:
       saturday:
-      - openharmony_welcome
+      - oniro_welcome
       sunday: []
     rooms:
-    - sopenharmony
+    - soniro
     events_per_room_per_day:
       saturday:
-        sopenharmony:
-        - openharmony_welcome
+        soniro:
+        - oniro_welcome
       sunday: {}
     start_time:
       saturday: '09:30'


### PR DESCRIPTION
Stand is not listed in

https://chat.fosdem.org/#stands

@agk shared me this repo link in
https://chat.fosdem.org/#/room/#stands:fosdem.org

HTML Files might need to be regenerated manually.

Cc: @toscalix
Forwarded: https://github.com/FOSDEM/website/pull/185
Relate-to: https://github.com/FOSDEM/stands-website/pull/124
Relate-to: https://gitlab.eclipse.org/groups/eclipse-wg/oniro-wg/proposal-incubation-stage-oniro/-/wikis/Events/FOSDEM#stand-wip
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>